### PR TITLE
BuffKit SCS 549 - Enhanced RepairCluster

### DIFF
--- a/BuffKit/AchievementScreenState/Patcher.cs
+++ b/BuffKit/AchievementScreenState/Patcher.cs
@@ -32,7 +32,7 @@ namespace BuffKit.AchievementScreenState
         private static void Prepare()
         {
             if (!_firstPrepare) return;
-            Settings.Settings.Instance.AddEntry("achievement screen state", "achievement screen state", v => _enabled = v, _enabled);
+            Settings.Settings.Instance.AddEntry("misc", "achievement screen state", v => _enabled = v, _enabled);
             _firstPrepare = false;
         }
 

--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="CopyAssemblies">
 
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
@@ -12,15 +12,19 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release to GameDir|AnyCPU'">
-	  <Optimize>True</Optimize>
+		<Optimize>True</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release to .zip|AnyCPU'">
-	  <Optimize>True</Optimize>
+		<Optimize>True</Optimize>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
+		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
 	</ItemGroup>
@@ -39,6 +43,18 @@
 		<BepInExDownload>https://github.com/BepInEx/BepInEx/releases/download/v5.4.22/BepInEx_x86_5.4.22.0.zip</BepInExDownload>
 		<DownloadFileName>BepInEx_x86_5.4.22.0.zip</DownloadFileName>
 	</PropertyGroup>
+
+	<Target Name="CopyAssemblies">
+		<Message Text="***** CopyAssemblies *****" Importance="high" />
+		<ReadLinesFromFile File="$(ProjectDir)\GamePath.txt">
+			<Output TaskParameter="Lines" PropertyName="GamePath" />
+		</ReadLinesFromFile>
+		<Message Text="Copy assemblies from $(GamePath)\GunsOfIcarusOnline_Data\Managed\ to ..\Assemblies\." Importance="high" />
+		<ItemGroup>
+			<SourceGameDlls Include="$(GamePath)\GunsOfIcarusOnline_Data\Managed\*.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(SourceGameDlls)" DestinationFolder="$(ProjectDir)\..\Assemblies\" />
+	</Target>
 
 	<Target Name="StageModDir" AfterTargets="Build">
 		<Message Text="***** StageModDir *****" Importance="high" />
@@ -75,9 +91,10 @@
 		<Message Text="Delete .\bin\$(Configuration)\" Importance="high" />
 		<RemoveDir Directories="$(ProjectDir)bin\$(Configuration)\" />
 	</Target>
-	
+
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp">
+		<!--Use Publicize="true" to make the assembly public. Thanks to BepInEx.AssemblyPublicizer.MSBuild. No need for Spanner now.-->
+		<Reference Include="Assembly-CSharp" Publicize="true">
 			<HintPath>..\Assemblies\Assembly-CSharp.dll</HintPath>
 		</Reference>
 		<Reference Include="Assembly-CSharp-firstpass">

--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>BuffKit</AssemblyName>
 		<Product>BuffKit</Product>
 		<Description>Guns of Icarus modding toolkit/moderation mod</Description>
-		<Version>521.1.0</Version>
+		<Version>549.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<Configurations>Debug;Release;Release to GameDir;Release to .zip</Configurations>

--- a/BuffKit/GunSelection/UIGunSelection.cs
+++ b/BuffKit/GunSelection/UIGunSelection.cs
@@ -12,7 +12,7 @@ namespace BuffKit.GunSelection
     public class UIGunSelection : UIBaseModalDialog
     {
 
-        protected override void Awake()
+        public override void Awake()
         {
             base.Awake();
             Instance = this;

--- a/BuffKit/ItemSelection/UICustomItemSelectionWindow.cs
+++ b/BuffKit/ItemSelection/UICustomItemSelectionWindow.cs
@@ -111,7 +111,7 @@ namespace BuffKit.ItemSelection
 
         private GameObject _obContent;
         private LayoutElement _leMenuPanel;
-        protected override void Awake()
+        public override void Awake()
         {
             base.Awake();
 

--- a/BuffKit/RepairCluster/Patcher.cs
+++ b/BuffKit/RepairCluster/Patcher.cs
@@ -514,6 +514,8 @@ namespace BuffKit.RepairCluster
                     if (!ActiveBuffBarRawImage.color.Equals(_colorYellow)) ActiveBuffBarRawImage.color = _colorYellow;
                     newPercentage = repairable.BuffDuration;
                 }
+                // No ActiveBuff.
+                else newPercentage = 0f;
                 newPreferredWidth = CalculatePreferredWidth(newPercentage);
                 if (ActiveBuffBarLayoutElement.preferredWidth != newPreferredWidth) ActiveBuffBarLayoutElement.preferredWidth = newPreferredWidth;
 

--- a/BuffKit/Settings/SettingType.cs
+++ b/BuffKit/Settings/SettingType.cs
@@ -202,6 +202,7 @@ namespace BuffKit.Settings
         public override void CreateUIElement(Transform parent, string entry)
         {
             LayoutElement le;
+            HorizontalLayoutGroup hlg;
 
             _toggles = new Toggle[_value.Rows, _value.Cols];
 
@@ -216,34 +217,38 @@ namespace BuffKit.Settings
             vlg.childForceExpandHeight = false;
             vlg.padding = new RectOffset(30, 0, 2, 0);
 
-            var obGridIconBar = new GameObject("icon bar");
-            obGridIconBar.transform.SetParent(obContent.transform, false);
-            var hlg = obGridIconBar.AddComponent<HorizontalLayoutGroup>();
-            hlg.spacing = 1;
-            hlg.childForceExpandWidth = false;
-            hlg.childForceExpandHeight = false;
-            foreach (var s in _value.Icons)
+            // Do not display icon row if there is only one and it is a blank icon.
+            if (!(_value.Icons.Count == 1 && _value.Icons[0] == UI.Resources.BlankIcon))
             {
-                var obIcon = new GameObject("icon");
-                obIcon.transform.SetParent(obGridIconBar.transform, false);
-                hlg = obIcon.AddComponent<HorizontalLayoutGroup>();
-                hlg.padding = new RectOffset(3, 3, 3, 3);
+                var obGridIconBar = new GameObject("icon bar");
+                obGridIconBar.transform.SetParent(obContent.transform, false);
+                hlg = obGridIconBar.AddComponent<HorizontalLayoutGroup>();
+                hlg.spacing = 1;
                 hlg.childForceExpandWidth = false;
                 hlg.childForceExpandHeight = false;
-                var obIconBox = new GameObject("box");
-                obIconBox.transform.SetParent(obIcon.transform, false);
-                var im = obIconBox.AddComponent<Image>();
-                im.sprite = s;
-                le = obIconBox.AddComponent<LayoutElement>();
-                le.minWidth = 25;
-                le.minHeight = 25;
-                le.preferredWidth = 25;
-                le.preferredHeight = 25;
+                foreach (var s in _value.Icons)
+                {
+                    var obIcon = new GameObject("icon");
+                    obIcon.transform.SetParent(obGridIconBar.transform, false);
+                    hlg = obIcon.AddComponent<HorizontalLayoutGroup>();
+                    hlg.padding = new RectOffset(3, 3, 3, 3);
+                    hlg.childForceExpandWidth = false;
+                    hlg.childForceExpandHeight = false;
+                    var obIconBox = new GameObject("box");
+                    obIconBox.transform.SetParent(obIcon.transform, false);
+                    var im = obIconBox.AddComponent<Image>();
+                    im.sprite = s;
+                    le = obIconBox.AddComponent<LayoutElement>();
+                    le.minWidth = 25;
+                    le.minHeight = 25;
+                    le.preferredWidth = 25;
+                    le.preferredHeight = 25;
+                }
+                var obSpacer = new GameObject("spacer");
+                obSpacer.transform.SetParent(obGridIconBar.transform, false);
+                le = obSpacer.AddComponent<LayoutElement>();
+                le.flexibleWidth = 1;
             }
-            var obSpacer = new GameObject("spacer");
-            obSpacer.transform.SetParent(obGridIconBar.transform, false);
-            le = obSpacer.AddComponent<LayoutElement>();
-            le.flexibleWidth = 1;
 
             for (var r = 0; r < _value.Rows; r++)
             {

--- a/BuffKit/Settings/SettingType.cs
+++ b/BuffKit/Settings/SettingType.cs
@@ -72,7 +72,12 @@ namespace BuffKit.Settings
         public override bool IsCompatible(object value) { return (value is bool); }
         public override void CreateUIElement(Transform parent, string entry)
         {
-            Builder.BuildMenuToggle(parent, out _toggle, entry, _value,
+            // Add ability to change display text from internal entry name. Use zero or one slash!
+            // Example: "feature one/enable" will display as "ENABLE"
+            // Example: "feature two enable" will display as "FEATURE TWO ENABLE"
+            var entrySplit = entry.Split('/');
+            var entryDisplay = entrySplit[entrySplit.Length - 1];
+            Builder.BuildMenuToggle(parent, out _toggle, entryDisplay, _value,
                 delegate (bool v) { Settings.Instance.SetEntry(entry, v); });
         }
     }
@@ -86,7 +91,12 @@ namespace BuffKit.Settings
         public override bool IsCompatible(object value) { return false; }
         public override void CreateUIElement(Transform parent, string entry)
         {
-            Builder.BuildMenuButton(parent, entry, entry,
+            // Add ability to change display text from internal entry name. Use zero or one slash!
+            // Example: "feature one/enable" will display as "ENABLE"
+            // Example: "feature two enable" will display as "FEATURE TWO ENABLE"
+            var entrySplit = entry.Split('/');
+            var entryDisplay = entrySplit[entrySplit.Length - 1];
+            Builder.BuildMenuButton(parent, entryDisplay, entryDisplay,
                 delegate { Settings.Instance.SetEntry<Dummy>(entry, null); });
         }
     }
@@ -195,7 +205,12 @@ namespace BuffKit.Settings
 
             _toggles = new Toggle[_value.Rows, _value.Cols];
 
-            Builder.BuildMenuDropdown(parent, entry, out var obContent);
+            // Add ability to change display text from internal entry name. Use zero or one slash!
+            // Example: "feature one/enable" will display as "ENABLE"
+            // Example: "feature two enable" will display as "FEATURE TWO ENABLE"
+            var entrySplit = entry.Split('/');
+            var entryDisplay = entrySplit[entrySplit.Length - 1];
+            Builder.BuildMenuDropdown(parent, entryDisplay, out var obContent);
             var vlg = obContent.AddComponent<VerticalLayoutGroup>();
             vlg.spacing = 1;
             vlg.childForceExpandHeight = false;
@@ -340,7 +355,12 @@ namespace BuffKit.Settings
         {
             _toggles = new List<Toggle>();
 
-            Builder.BuildMenuDropdown(parent, entry, out var obContent);
+            // Add ability to change display text from internal entry name. Use zero or one slash!
+            // Example: "feature one/enable" will display as "ENABLE"
+            // Example: "feature two enable" will display as "FEATURE TWO ENABLE"
+            var entrySplit = entry.Split('/');
+            var entryDisplay = entrySplit[entrySplit.Length - 1];
+            Builder.BuildMenuDropdown(parent, entryDisplay, out var obContent);
             var vlg = obContent.AddComponent<VerticalLayoutGroup>();
             vlg.spacing = 3;
             vlg.childForceExpandHeight = false;

--- a/BuffKit/Speedometer/Patcher.cs
+++ b/BuffKit/Speedometer/Patcher.cs
@@ -20,7 +20,7 @@ namespace BuffKit.Speedometer
 
             Util.OnGameInitialize += delegate
             {
-                var gridIcons = new List<Sprite>() { Resources.PilotIcon/*, Resources.GunnerIcon, Resources.EngineerIcon */};
+                var gridIcons = new List<Sprite>() { Resources.BlankIcon/*, Resources.GunnerIcon, Resources.EngineerIcon */};
                 var gridLabels = new List<string> { "horizontal speed", "vertical speed", "rotation speed", "x position east/west", "y position altitude", "z position north/south" };
                 DisplaySettings = new ToggleGrid(gridIcons, gridLabels, true);
                 Settings.Settings.Instance.AddEntry("speedometer", "speedometer display", v => DisplaySettings = v, DisplaySettings);

--- a/BuffKit/Speedometer/Patcher.cs
+++ b/BuffKit/Speedometer/Patcher.cs
@@ -29,15 +29,15 @@ namespace BuffKit.Speedometer
             _firstPrepare = false;
         }
 
-        [HarmonyPatch(typeof(Mission), "RemoteInitialize")]
+        [HarmonyPatch(typeof(UIManager.UIMatchBlockState), nameof(UIManager.UIMatchBlockState.Exit))]
         [HarmonyPostfix]
-        private static void Mission_RemoteInitialize()
+        private static void UIManager_UIMatchBlockState_Exit()
         {
             if (!Enabled) return;
             Speedometer.Initialize();
         }
 
-        [HarmonyPatch(typeof(UIManager.UIGamePlayState), "ActivateHUDElements")]
+        [HarmonyPatch(typeof(UIManager.UIGamePlayState), nameof(UIManager.UIGamePlayState.ActivateHUDElements))]
         [HarmonyPostfix]
         private static void UIManager_ActivateHUDElements()
         {
@@ -45,7 +45,7 @@ namespace BuffKit.Speedometer
             Speedometer.SetActive(true);
         }
 
-        [HarmonyPatch(typeof(UIManager.UIGamePlayState), "DeactivateHUDElements")]
+        [HarmonyPatch(typeof(UIManager.UIGamePlayState), nameof(UIManager.UIGamePlayState.DeactivateHUDElements))]
         [HarmonyPostfix]
         private static void UIManager_DeactivateHUDElements()
         {

--- a/BuffKit/Speedometer/Speedometer.cs
+++ b/BuffKit/Speedometer/Speedometer.cs
@@ -14,8 +14,6 @@ namespace BuffKit.Speedometer
 
         private static bool _shouldBeEnabled = false;
         private static bool _doUpdateShouldBeEnabled = false;
-        // Practice, Pirate Deathmatch 1 ship, Pirate Deathmatch 2+ ships.
-        private static readonly List<RegionGameMode> _practiceGameModes = [RegionGameMode.PRACTICE, RegionGameMode.NOVICE_DEATHMATCH, RegionGameMode.PRACTICE_NOVICE_DEATHMATCH];
         private static readonly List<GameObject> _meterObjects = [];
         private static GameObject _mainObject;
         private static TextMeshProUGUI _speedometerText;
@@ -117,7 +115,7 @@ namespace BuffKit.Speedometer
             var currentGameMode = Mission.Instance.Map.GameMode;
             var isNotSpectator = !NetworkedPlayer.Local.IsSpectator;
             var isCaptain = NetworkedPlayer.Local.IsCaptain;
-            var isPractice = _practiceGameModes.Contains(currentGameMode);
+            var isPractice = Util.PracticeGameModes.Contains(currentGameMode);
             var isCoop = RegionGameModeUtil.IsCoop(currentGameMode);
             var isJestersParade = Mission.Instance.Map.Name == "Test_Race_OblivionApproach_FFA";
             _shouldBeEnabled = isCaptain && isNotSpectator && (isPractice || isCoop || isJestersParade);

--- a/BuffKit/Speedometer/Speedometer.cs
+++ b/BuffKit/Speedometer/Speedometer.cs
@@ -58,18 +58,18 @@ namespace BuffKit.Speedometer
         {
             // Applies "speedometer display" settings to the _meterObjects.
             if (_mainObject == null) return;
-
-            var currentClass = -1;
-            switch (NetworkedPlayer.Local.PlayerClass)
-            {
-                case AvatarClass.Pilot:
-                    currentClass = 0; break;
-                    //case AvatarClass.Gunner:
-                    //    currentClass = 1; break;
-                    //case AvatarClass.Engineer:
-                    //    currentClass = 2; break;
-            }
-            if (currentClass == -1) return;
+            // Always apply settings from Pilot, since we are not using class specific settings.
+            var currentClass = 0;
+            //switch (NetworkedPlayer.Local.PlayerClass)
+            //{
+            //    case AvatarClass.Pilot:
+            //        currentClass = 0; break;
+            //    case AvatarClass.Gunner:
+            //        currentClass = 1; break;
+            //    case AvatarClass.Engineer:
+            //        currentClass = 2; break;
+            //}
+            //if (currentClass == -1) return;
 
             var settings = SpeedometerPatcher.DisplaySettings;
             bool settingValue;
@@ -104,6 +104,9 @@ namespace BuffKit.Speedometer
             _positionZText.text = baseTextNoDecimal.F([currentShip.Position.z]);
         }
 
+        /// <summary>
+        /// Determines when the Speedometer is allowed to be enabled. Updates <c>_shouldBeEnabled</c>. Called when entering a running match on loading screen exit.
+        /// </summary>
         private static void UpdateShouldBeEnabled() // :c
         {
             if (Mission.Instance == null)
@@ -113,12 +116,12 @@ namespace BuffKit.Speedometer
             }
             var currentGameMode = Mission.Instance.Map.GameMode;
             var isNotSpectator = !NetworkedPlayer.Local.IsSpectator;
-            var isPilot = NetworkedPlayer.Local.PlayerClass == AvatarClass.Pilot;
+            var isCaptain = NetworkedPlayer.Local.IsCaptain;
             var isPractice = _practiceGameModes.Contains(currentGameMode);
             var isCoop = RegionGameModeUtil.IsCoop(currentGameMode);
             var isJestersParade = Mission.Instance.Map.Name == "Test_Race_OblivionApproach_FFA";
-            _shouldBeEnabled = isPilot && isNotSpectator && (isPractice || isCoop || isJestersParade);
-            MuseLog.Info($"_shouldBeEnabled: {_shouldBeEnabled}, isPilot: {isPilot} && isNotSpectator: {isNotSpectator} && (isPractice: {isPractice} || isCoop: {isCoop} || isJestersParade: {isJestersParade}).");
+            _shouldBeEnabled = isCaptain && isNotSpectator && (isPractice || isCoop || isJestersParade);
+            MuseLog.Info($"_shouldBeEnabled: {_shouldBeEnabled}, isCaptain: {isCaptain} && isNotSpectator: {isNotSpectator} && (isPractice: {isPractice} || isCoop: {isCoop} || isJestersParade: {isJestersParade}).");
         }
 
         private static GameObject BuildUi(Transform parent)

--- a/BuffKit/TitleSelection/UICustomTitleSelection.cs
+++ b/BuffKit/TitleSelection/UICustomTitleSelection.cs
@@ -18,7 +18,7 @@ namespace BuffKit.TitleSelection
         private GameObject _obContent;
         private InputField _searchField;
 
-        protected override void Awake()
+        public override void Awake()
         {
             base.Awake();
 

--- a/BuffKit/Util/Util.cs
+++ b/BuffKit/Util/Util.cs
@@ -19,6 +19,9 @@ namespace BuffKit
         public static event Notify OnGameInitialize;     // Called once before the launcher "Play" button can be pressed
         public static event Notify OnLobbyLoad;          // Called when the game loads to menu and after every match
 
+        // Practice, Pirate Deathmatch 1 ship, Pirate Deathmatch 2+ ships.
+        public static readonly List<RegionGameMode> PracticeGameModes = [RegionGameMode.PRACTICE, RegionGameMode.NOVICE_DEATHMATCH, RegionGameMode.PRACTICE_NOVICE_DEATHMATCH];
+
         public static bool HasModPrivilege(MatchLobbyView mlv)
         {
             try

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Created by Trgk and Ightrril. Dr. Pit Lazarus is the current developer.
    - Delete folder `Guns of Icarus Online\BepInEx\plugins\BuffKit`.
    - If you want to backup the folder, the backup cannot live in the `Guns of Icarus Online\BepInEx\plugins` folder. The mod loader BepInEx will load any .dll files in there. I would right-click the `BuffKit` folder and compress to a .zip file.
 4. Manual complete mod loader uninstall:
-    - Delete folder: `Guns of Icarus Online\BepInEx`. Make a backup if there is any mod settings you want to keep.
-    - Delete files: `changelog.txt doorstop_config.ini version.dll` in `Guns of Icarus Online` folder.
+    - Delete folder `Guns of Icarus Online\BepInEx`. Make a backup if there is any mod settings you want to keep.
+    - Delete files `changelog.txt doorstop_config.ini version.dll` in `Guns of Icarus Online` folder.
 
 ## Features
 Popular features include:
@@ -45,27 +45,36 @@ Any code editor should work if you can use build configs `Release to GameDir` an
 
 Clone the repo and open up the BuffKit solution.
 
-Edit `./Binaries/spanner_config.toml` and `./BuffKit/GamePath.txt` to your game folder. 
-Example `C:\Program Files (x86)\Steam\steamapps\common\Guns of Icarus Online`.
+Edit `.\BuffKit\GamePath.txt` to point to your game folder.  
+Example: `C:\Program Files (x86)\Steam\steamapps\common\Guns of Icarus Online`.
 
-`./Binaries/Spanner.exe` is the tool that will copy the game assemblies to `./Assemblies/`. 
-It will deprivatize classes and methods so you can use them without needing to use reflection. 
-Run it with terminal or run it normally and check the `spanner_log.txt` for errors. 
-You need .NET 8 runtime to run it. 
-You should only need to run it once, unless you make changes to the spanner config.
+This project does not use reflection, but publicizes game assemblies with [BepInEx.AssemblyPublicizer.MSBuild](https://github.com/BepInEx/BepInEx.AssemblyPublicizer). Simply add `Publicize="true"` to the `Reference` tag in `BuffKit.csproj`.
 
 To build BuffKit, use these build configs: 
 
-`Release to GameDir`: Reads `./BuffKit/GamePath.txt` and copies it over.
+`Release to GameDir`: Reads `.\BuffKit\GamePath.txt` and copies it over.
 
-`Release to .zip`: Outputs `./BuffKit/bin/BuffKit_SCS_$(Version).zip`.
+`Release to .zip`: Outputs `.\BuffKit\bin\BuffKit_SCS_$(Version).zip`.
 
-All build configs will stage the mod directory in `./BuffKit/bin/temp/`. 
+You may see reference errors after cloning. Ensure `.\BuffKit\GamePath.txt` is correct and build the project. The InitialTarget `CopyAssemblies` will copy assembiles before the build process starts.  
+All build configs will stage the mod directory in `.\BuffKit\bin\temp\`. 
 It will download BepInEx core files, and copy BuffKit.dll and assets. 
-See `./BuffKit/BuffKit.csproj` for the exact steps.
+See `.\BuffKit\BuffKit.csproj` for the exact steps.
 
 **The BuffKit must grow.**
 
-## Spanner building
-Nothing much here. Open the Spanner solution and use publish to build the single file Spanner.exe. 
-Put the new .exe in `./Binaries/`.
+## Spanner
+> [!WARNING]
+> Deprecated. Replaced with [BepInEx.AssemblyPublicizer.MSBuild](https://github.com/BepInEx/BepInEx.AssemblyPublicizer).
+
+~~Edit `.\Binaries\spanner_config.toml` and `.\BuffKit\GamePath.txt` to your game folder. 
+Example `C:\Program Files (x86)\Steam\steamapps\common\Guns of Icarus Online`.~~
+
+~~`./Binaries/Spanner.exe` is the tool that will copy the game assemblies to `.\Assemblies\`. 
+It will deprivatize classes and methods so you can use them without needing to use reflection. 
+Run it with terminal or run it normally and check the `spanner_log.txt` for errors. 
+You need .NET 8 runtime to run it. 
+You should only need to run it once, unless you make changes to the spanner config.~~
+
+~~Nothing much here. Open the Spanner solution and use publish to build the single file Spanner.exe. 
+Put the new .exe in `.\Binaries\`.~~


### PR DESCRIPTION
### What's New?

- **RepairCluster**: New status indicators and progress bars have been added.
  - `show status failsafe`. Display a green plus icon on indicator.
  - `show status fireproof`. Display a blue waterdrop icon on indicator.
  - `show bar repair progress`. Display rebuild or repair cooldown in thin white progress bar.
  - `show bar active buff`. Display active buff in thin yellow (dynabuff) or blue (armor kit) progress bar.
  - All settings enabled by default. Main `repair cluster` setting remains disabled by default.
  - Still only available in PvE. Now available in practice modes.
 ![Screenshot](https://github.com/user-attachments/assets/a7d0d482-db74-450c-9776-b974dec78557)  
[Video Demo](https://github.com/user-attachments/assets/db545c23-b8f6-4a4f-912c-0f0202a9ef75)


- **Speedometer**: 
  - Fix UI flicker on loading screen.
  - Hide the pilot icon under the `speedometer display` settings.
  - Change allowed classes from Pilot to Captain. This allows all classes in the captain's slot to use Speedometer.
  - Still only available in PvE and practice modes.
 - **AchievementScreenState**: Move setting under `misc`.
 - **Developer Changes**:
   - [Settings Add Custom Display Label Support for Entries](https://github.com/DrPitLazarus/buffkit/commit/79fd5807cc9a666812491eaee08fdd340ad5fe1f)
   - [Settings Add Ability to Hide Icon Row in ToggleGrid](https://github.com/DrPitLazarus/buffkit/commit/7abc1f872f74846d9c043a2a7725750e5e6f99a7)
   - [Dev Replace Spanner Program for BepInEx.AssemblyPublicizer.MSBuild](https://github.com/DrPitLazarus/buffkit/commit/d860c905fb158e9db761f40937fb1326cad8785b) 
   - [Speedometer Move _practiceGameModes to Util](https://github.com/DrPitLazarus/buffkit/commit/992fe9c2be4225531b052e84ab5a8c3f726c5c28)

[Install/Uninstall Instructions](https://github.com/DrPitLazarus/buffkit?tab=readme-ov-file#install-options)

gl & hf