### PR TITLE
BuffKit SCS 550 - CopyShipLoadout

### DIFF
--- a/BuffKit/AutoAcceptLoadout/Patcher.cs
+++ b/BuffKit/AutoAcceptLoadout/Patcher.cs
@@ -8,6 +8,7 @@ namespace BuffKit.AutoAcceptLoadout
     class UINewAcceptLoadoutDialog_Show
     {
         private static bool enableAutoAccept = false;
+        private static bool showAutoAcceptNotification = true;
 
         private static bool firstPrepare = true;
         private static void Prepare()
@@ -15,6 +16,7 @@ namespace BuffKit.AutoAcceptLoadout
             if (firstPrepare)
             {
                 Settings.Settings.Instance.AddEntry("loadout manager", "auto accept loadouts", v => enableAutoAccept = v, enableAutoAccept);
+                Settings.Settings.Instance.AddEntry("loadout manager", "auto accept loadouts notification", v => showAutoAcceptNotification = v, showAutoAcceptNotification);
                 firstPrepare = false;
             }
         }
@@ -31,6 +33,11 @@ namespace BuffKit.AutoAcceptLoadout
 
             var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
             typeof(UINewAcceptLoadoutDialog).GetMethod("Accept", flags).Invoke(__instance, null);
+
+            if (showAutoAcceptNotification)
+            {
+                Util.SendToastNotification($"Auto accepted {clazz} loadout from {captainName}.");
+            }
 
             return false;
         }

--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>BuffKit</AssemblyName>
 		<Product>BuffKit</Product>
 		<Description>Guns of Icarus modding toolkit/moderation mod</Description>
-		<Version>549.0.0</Version>
+		<Version>550.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<Configurations>Debug;Release;Release to GameDir;Release to .zip</Configurations>

--- a/BuffKit/ChaosRandomizer/Patcher.cs
+++ b/BuffKit/ChaosRandomizer/Patcher.cs
@@ -24,7 +24,7 @@ namespace BuffKit.ChaosRandomizer
                         if (!ChaosRandomizer.Enabled) return;
                         ChaosRandomizer.Instance.ExitLobby(mlv);
                     };
-                    Settings.Settings.Instance.AddEntry("misc", "chaos skirmish ref panel", delegate (bool v)
+                    Settings.Settings.Instance.AddEntry("ref tools", "chaos skirmish ref panel", delegate (bool v)
                     {
                         ChaosRandomizer.Enabled = v;
                         if (v && MatchLobbyView.Instance != null)

--- a/BuffKit/CopyShipLoadout/Patcher.cs
+++ b/BuffKit/CopyShipLoadout/Patcher.cs
@@ -1,0 +1,223 @@
+﻿using HarmonyLib;
+using Muse.Goi2.Entity.Vo;
+using Muse.Networking;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BuffKit.CopyShipLoadout
+{
+    [HarmonyPatch]
+    public class CopyShipLoadout
+    {
+        private static bool _enabled = true;
+        private static bool _showCopyShipLoadoutNotification = true;
+        private static bool _firstMainMenuState = true;
+
+        private static ShipDataController _shipDataController => UIManager.UINewShipState.instance.shipDataController;
+        private static UIShipCustomizationScreen _shipCustomizationScreen => UIShipCustomizationScreen.Instance;
+
+        /// <summary>
+        /// Feature initialization. Create settings.
+        /// </summary>
+        [HarmonyPatch(typeof(UIManager.UINewMainMenuState), nameof(UIManager.UINewMainMenuState.Enter))]
+        [HarmonyPostfix]
+        private static void Initialize()
+        {
+            if (!_firstMainMenuState) return;
+            _firstMainMenuState = false;
+            Settings.Settings.Instance.AddEntry("loadout manager", "loadout manager/copy ship loadout", v => _enabled = v, _enabled);
+            Settings.Settings.Instance.AddEntry("loadout manager", "loadout manager/copy ship loadout notification", v => _showCopyShipLoadoutNotification = v, _showCopyShipLoadoutNotification);
+
+            // AllShips is null if the player has not opened the ship customization screen yet.
+            if (_shipDataController.AllShips == null)
+            {
+                _shipDataController.QueryShipsFromServer();
+            }
+        }
+
+        /// <summary>
+        /// Add the "Copy Loadout" button to the footer of the ship customization screen. Works on your own ship and previewing other ships.
+        /// </summary>
+        [HarmonyPatch(typeof(UIManager.UINewShipInspectionState), nameof(UIManager.UINewShipInspectionState.Enter))]
+        [HarmonyPatch(typeof(UIManager.UINewShipState), nameof(UIManager.UINewShipState.Enter))]
+        [HarmonyPostfix]
+        private static void AddCopyLoadoutButtonToFooter()
+        {
+            if (!_enabled) return;
+            UIPageFrame.Instance.footer.AddButton("Copy Loadout", CopyFromShipCustomizationScreen);
+        }
+
+        /// <summary>
+        /// Action for the "Copy Loadout" button. Opens a dropdown modal dialog with the player's ship presets.
+        /// </summary>
+        private static void CopyFromShipCustomizationScreen()
+        {
+            // Gather ship data from the ship customization screen.
+            var shipModelId = _shipCustomizationScreen.currentShip.Model.Id;
+            var shipModelName = _shipCustomizationScreen.currentShip.Model.NameText.En;
+            var shipGunSlotNamesAndGunIds = new Dictionary<string, int>();
+            foreach (var gunSlot in _shipCustomizationScreen.gunSlots)
+            {
+                // All 6 gun slots always exist, but they may not be activated.
+                // Was getting gun slot names conflicts in the dictionary.
+                if (!gunSlot.Activated) continue;
+                var gunSlotName = gunSlot.Item.Name;
+                var gunId = gunSlot.Item.GunId;
+                shipGunSlotNamesAndGunIds.Add(gunSlotName, gunId);
+            }
+            // Check if the player has the ship model in their inventory.
+            var shipViewObject = GetShipViewObjectByShipModelId(shipModelId);
+            if (shipViewObject == null)
+            {
+                Util.SendToastNotification($"ERROR: Cannot copy. You do not have the ship {shipModelName}.", true);
+                MuseLog.Info($"ERROR: Ship model ID {shipModelId} was not found in player's ShipDataController.AllShips. Exiting.");
+                return;
+            }
+            var playerShipId = shipViewObject.Id;
+
+            // Initialize the dropdown modal dialog.
+            var dialogTitle = "Copy Ship Loadout";
+            var dialogMessage = "Select the ship preset slot you would like to save over.";
+            var indexedShipLoadoutViewObjectList = shipViewObject.Presets.Select((shipLoadoutViewObject, index) =>
+                new IndexedShipLoadoutViewObject { Index = index, ShipLoadoutViewObject = shipLoadoutViewObject })
+                .ToList();
+            var dropdownOptions = UINewModalDialog.DropdownSetting.CreateSetting<IndexedShipLoadoutViewObject>(
+                indexedShipLoadoutViewObjectList,
+                // Method to get generate text for each dropdown option.
+                // Examples: "Preset 1" or "Preset 1: ShipPresetNameHere" or "Preset 1: ShipPresetNameHere (active) or Preset 1 (active)"
+                (IndexedShipLoadoutViewObject preset) =>
+                {
+                    var dropdownText = $"Preset {preset.Index + 1}";
+                    if (preset.ShipLoadoutViewObject.Name != null)
+                    {
+                        dropdownText += $": {preset.ShipLoadoutViewObject.Name}";
+                    }
+                    if (shipModelId == _shipDataController?.ActiveShip.ModelId && preset.Index == _shipDataController?.ActiveShip.CurrentPresetIndex)
+                    {
+                        dropdownText += " (active)";
+                    }
+                    return dropdownText;
+                },
+                indexedShipLoadoutViewObjectList.First());
+            // Show the dropdown modal dialog.
+            UINewModalDialog.Select(dialogTitle, dialogMessage, dropdownOptions, (int destinationPresetIndex) =>
+                {
+                    // If cancelled, do nothing.
+                    if (destinationPresetIndex < 0)
+                    {
+                        return;
+                    }
+                    if (destinationPresetIndex > shipViewObject.Presets.Count - 1)
+                    {
+                        MuseLog.Info($"ERROR: Player's ShipViewObject.Presets index out of bounds. Got {destinationPresetIndex}. Expected <= {shipViewObject.Presets.Count - 1}. Exiting.");
+                        return;
+                    }
+                    SaveShipLoadout(playerShipId, destinationPresetIndex, shipGunSlotNamesAndGunIds, (response) =>
+                    {
+                        if (response.Success)
+                        {
+                            var message = $"Ship loadout copied to {shipModelName} in preset {destinationPresetIndex + 1}.";
+                            MuseLog.Info(message);
+                            if (_showCopyShipLoadoutNotification)
+                            {
+                                Util.SendToastNotification(message);
+                            }
+                        }
+                        // Download the changes we just made.
+                        _shipDataController.QueryShipsFromServer();
+                    });
+                }
+            );
+        }
+
+        /// <summary>
+        /// Given a ship model ID, get the player's matching <see cref="ShipViewObject"/> in <see cref="ShipDataController.AllShips"/>.
+        /// </summary>
+        /// <param name="shipModelId"></param>
+        /// <returns><see cref="ShipViewObject"/> or <c>null</c> if not found.</returns>
+        private static ShipViewObject GetShipViewObjectByShipModelId(int shipModelId)
+        {
+            var shipViewObject = _shipDataController.AllShips.Where(ship => ship.ModelId == shipModelId).FirstOrDefault();
+            return shipViewObject;
+        }
+
+        /// <summary>
+        /// Save player ship loadout. Depends on the which game mode (PvP or PvE) the player is in. Saves only the guns and does not modify anything else.
+        /// </summary>
+        /// <param name="playerShipId">Unique player-ship ID from <see cref="ShipViewObject"/>.</param>
+        /// <param name="shipPresetIndex"></param>
+        /// <param name="gunSlotNameAndGunIdDictionary"></param>
+        /// <param name="responseCallback"></param>
+        private static void SaveShipLoadout(int playerShipId, int shipPresetIndex, Dictionary<string, int> gunSlotNameAndGunIdDictionary, Action<ExtensionResponse> responseCallback = null)
+        {
+            var playerShipIdAndPresetIndexDictionary = new Dictionary<int, int> { { playerShipId, shipPresetIndex } };
+            var shipGunsDictionary = CreateShipGunsDictionary(playerShipId, shipPresetIndex, gunSlotNameAndGunIdDictionary);
+            var emptyLoadoutNamesDictionary = new Dictionary<Muse.Common.MuseTuple<int, int>, string>();
+            var emptySkills = "";
+            SubDataActions.CustomizeShips(playerShipId, playerShipIdAndPresetIndexDictionary, shipGunsDictionary, emptyLoadoutNamesDictionary, emptySkills, (response) =>
+            {
+                responseCallback?.Invoke(response);
+            });
+        }
+
+        /// <summary>
+        /// Helper method for <c>SaveShipLoadout()</c>. Transforms gun data into the required structure for <c>SubDataActions.CustomizeShips()</c>.
+        /// </summary>
+        /// <param name="playerShipId">Unique player-ship ID from <see cref="ShipViewObject"/>.</param>
+        /// <param name="shipPresetIndex"></param>
+        /// <param name="gunSlotNameAndGunId"></param>
+        /// <returns></returns>
+        private static Dictionary<Muse.Common.MuseTuple<int, int, string>, int> CreateShipGunsDictionary(int playerShipId, int shipPresetIndex, Dictionary<string, int> gunSlotNameAndGunId)
+        {
+            var shipGunsDictionary = new Dictionary<Muse.Common.MuseTuple<int, int, string>, int>();
+            foreach (var gunSlotEntry in gunSlotNameAndGunId)
+            {
+                var gunSlotName = gunSlotEntry.Key;
+                var gunId = gunSlotEntry.Value;
+                var gunTuple = new Muse.Common.MuseTuple<int, int, string>(playerShipId, shipPresetIndex, gunSlotName);
+                shipGunsDictionary.Add(gunTuple, gunId);
+            }
+            return shipGunsDictionary;
+        }
+
+        /// <summary>
+        /// Class to hold the index and <see cref="Muse.Goi2.Entity.Vo.ShipViewObject"/> for the dropdown modal dialog.
+        /// </summary>
+        public class IndexedShipLoadoutViewObject
+        {
+            public int Index { get; set; }
+            public ShipLoadoutViewObject ShipLoadoutViewObject { get; set; }
+        }
+
+        // Testing method. Do not use.
+        private static void TestSetJunker0ToAllFlares()
+        {
+            var shipViewObject = _shipDataController.AllShips.Where(ship => ship.Model.NameText.En == "Junker").First();
+            var playerShipId = shipViewObject.Id;
+            var shipPresetIndex = 0;
+            var gunId = 198; // Flare Gun
+            var gunSlotNameAndGunIdDictionary = new Dictionary<string, int>();
+            for (var gunSlotIndex = 0; gunSlotIndex < shipViewObject.Model.GunSlots; gunSlotIndex++)
+            {
+                gunSlotNameAndGunIdDictionary.Add($"gun-slot-{gunSlotIndex + 1}", gunId);
+            }
+            SaveShipLoadout(playerShipId, shipPresetIndex, gunSlotNameAndGunIdDictionary);
+        }
+
+        // Testing method. Do not use.
+        private static void TestSetJunker0ToAllHarpoons()
+        {
+            var shipViewObject = _shipDataController.AllShips.Where(ship => ship.Model.NameText.En == "Junker").First();
+            var playerShipId = shipViewObject.Id;
+            var shipPresetIndex = 0;
+            var gunId = 195; // Harpoon Gun
+            var gunSlotNameAndGunIdDictionary = new Dictionary<string, int>();
+            for (var gunSlotIndex = 0; gunSlotIndex < shipViewObject.Model.GunSlots; gunSlotIndex++)
+            {
+                gunSlotNameAndGunIdDictionary.Add($"gun-slot-{gunSlotIndex + 1}", gunId);
+            }
+            SaveShipLoadout(playerShipId, shipPresetIndex, gunSlotNameAndGunIdDictionary);
+        }
+    }
+}

--- a/BuffKit/MapPicker/Patcher.cs
+++ b/BuffKit/MapPicker/Patcher.cs
@@ -14,7 +14,7 @@ namespace BuffKit.MapPicker
             
             OnGameInitialize += delegate
             {
-                Settings.Settings.Instance.AddEntry("map picker", "only show DM maps", delegate (bool v)
+                Settings.Settings.Instance.AddEntry("ref tools", "only show DM maps", delegate (bool v)
                 {
                     MapPicker.FilterNonDM = v;
                 }, MapPicker.FilterNonDM);

--- a/BuffKit/Util/Util.cs
+++ b/BuffKit/Util/Util.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using LitJson;
+﻿using LitJson;
 using Muse.Common;
 using Muse.Goi2.Entity;
 using Muse.Goi2.Entity.Vo;
+using MuseBase.Multiplayer;
 using MuseBase.Multiplayer.Photon;
 using MuseBase.Multiplayer.Unity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Resources = BuffKit.UI.Resources;
 
@@ -228,6 +229,29 @@ namespace BuffKit
             PilotSkillIds.Sort();
             GunnerSkillIds.Sort();
             EngineerSkillIds.Sort();
+        }
+
+        /// <summary>
+        /// Queue a toast notification in top-right with title "System Message" and specified message. Can log to the notification panel.
+        /// </summary>
+        /// <param name="message">Message string. Can use <c>\n</c> for new line.</param>
+        /// <param name="showInNotificationPanel">Log notification in the notification panel. Default <c>false</c>.</param>
+        public static void SendToastNotification(string message, bool showInNotificationPanel = false)
+        {
+            var notificationType = showInNotificationPanel ? NotificationType.ServerAlert : NotificationType.ConsoleAlert;
+            var messageDictionary = new Dictionary<string, object> {
+                { "content", message }
+            };
+            NotificationDispatch.RaiseNotification(notificationType, messageDictionary);
+        }
+
+        /// <summary>
+        /// Add a red console message to the chat. Only visible to the player.
+        /// </summary>
+        /// <param name="message">Message string. Can use <c>\n</c> for new line.</param>
+        public static void SendConsoleChatMessage(string message)
+        {
+            MuseWorldClient.Instance.ChatHandler.AddMessage(ChatMessage.Console(message));
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -8,14 +8,24 @@ A collection of game modifications that feature:
 
 Created by Trgk and Ightrril. Dr. Pit Lazarus is the current developer.
 
+## Features
+Popular features include:
+- Loadout Viewer: see ship and player loadouts all at once.
+- Auto accept loadout recommendations and sort by preference.
+- Skipping the Launcher and Intro movie.
+- Better gun info tooltips and ship stat panels.
+
+A complete description of all features will be added soon. In the meantime, you can learn some of the features from reading the [release notes](https://github.com/DrPitLazarus/buffkit/releases). Work-in-Progress [BuffKit Wiki](https://github.com/DrPitLazarus/buffkit/wiki).
+
 ## Install Options
 1. [BuffKit Mod Installer for Windows](BuffKitModInstaller/#readme)
 2. Manual install from .zip file.
-    1. Visit latest [release page](https://github.com/DrPitLazarus/buffkit/releases/latest) and download .zip file.
+    1. Visit latest [release page](https://github.com/DrPitLazarus/buffkit/releases/latest) and download .zip file. Or [view all releases](https://github.com/DrPitLazarus/buffkit/releases).
     2. Open downloaded .zip file.
     3. Open your `Guns of Icarus Online` folder.
     4. Drag and drop .zip contents to your game folder, overwrite if prompted.
-    5. **Additional steps for Linux**: Use Proton and add to your launch options: `WINEDLLOVERRIDES="version=n,b" %command%`.
+    5. **Additional steps for Linux**: Use Proton and add to your launch options:  
+    `WINEDLLOVERRIDES="version=n,b" %command%`.
 
 ## Uninstall Options
 1. Use either uninstall option in [BuffKit Mod Installer for Windows](BuffKitModInstaller/#readme).
@@ -28,15 +38,6 @@ Created by Trgk and Ightrril. Dr. Pit Lazarus is the current developer.
 4. Manual complete mod loader uninstall:
     - Delete folder `Guns of Icarus Online\BepInEx`. Make a backup if there is any mod settings you want to keep.
     - Delete files `changelog.txt doorstop_config.ini version.dll` in `Guns of Icarus Online` folder.
-
-## Features
-Popular features include:
-- Loadout Viewer: see ship and player loadouts all at once.
-- Auto accept loadout recommendations and sort by preference.
-- Skipping the Launcher and Intro movie.
-- Better gun info tooltips and ship stat panels.
-
-A complete description of all features will be added soon. In the meantime, you can learn some of the features from reading the [release notes](https://github.com/DrPitLazarus/buffkit/releases).
 
 # Developer Notes
 ## Building and installing


### PR DESCRIPTION
### What's New?

- New **CopyShipLoadout** Feature: 
  - Adds a "Copy Loadout" button to the footer of the UIShipCustomizationScreen. Works for your own ship and previewing other player's ships. (Yes, you can use this to mirror ships.)
  - When clicked, you are prompted to select which ship preset you want to save to. Choices will show preset names if set. If copied ship model is the same as your active ship, "(active)" is added to your active preset.
  - Press OK and your active ship is now the ship you copied. Displays a brief notification if enabled. "Ship loadout copied to {shipModelName} in preset {presetNumber}."
  - Settings enabled by default.
  - `loadout manager > copy ship loadout`
  - `loadout manager > copy ship loadout notification`
[Screenshot](https://github.com/user-attachments/assets/8cfc423c-7bec-4308-ab05-1ed960ce9402)
[Video Demo](https://github.com/user-attachments/assets/7a07b7dd-f705-4b41-8b29-29772eab57c0)

- **AutoAcceptLoadout**: 
  - Add brief notification when auto accepting loadouts. "Auto accepted {className} loadout from {captainName}."
  - Setting `loadout manager > auto accept loadouts notification` enabled by default.
![Screenshot (245)](https://github.com/user-attachments/assets/3d80664d-4137-45d0-848e-ee5c40184b9c)

- **ChaosRandomizer**: Move setting from `misc` to `ref tools > chaos skirmish ref panel`.
- **MapPicker**: Move setting from `map picker` to `ref tools > only show DM maps`.
- **Developer Changes**:
  - [Util Add SendToastNotification and SendConsoleChatMessage Methods](https://github.com/DrPitLazarus/buffkit/commit/c7c118669d131e18b1ab86d22f2a9c48e6ab3934)

[Install/Uninstall Instructions](https://github.com/DrPitLazarus/buffkit?tab=readme-ov-file#install-options)

gl & hf